### PR TITLE
Implement cleanup and configurability in `stresstest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,9 @@ name = "bytesize"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -1003,6 +1006,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -2478,15 +2497,18 @@ name = "stresstest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argh",
  "bytes",
  "bytesize",
  "futures",
  "futures-util",
+ "humantime-serde",
  "rand",
  "rand_distr",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sketches-ddsketch",
  "tokio",
  "yansi",

--- a/service/src/backend/local_fs.rs
+++ b/service/src/backend/local_fs.rs
@@ -56,4 +56,9 @@ impl Backend for LocalFs {
         let stream = ReaderStream::new(file).map_err(anyhow::Error::from);
         Ok(Some(stream.boxed()))
     }
+
+    async fn delete_file(&self, path: &str) -> anyhow::Result<()> {
+        let path = self.path.join(path);
+        Ok(tokio::fs::remove_file(path).await?)
+    }
 }

--- a/service/src/backend/mod.rs
+++ b/service/src/backend/mod.rs
@@ -16,4 +16,5 @@ pub type BackendStream = BoxStream<'static, anyhow::Result<Bytes>>;
 pub trait Backend {
     async fn put_file(&self, path: &str, stream: BackendStream) -> anyhow::Result<()>;
     async fn get_file(&self, path: &str) -> anyhow::Result<Option<BackendStream>>;
+    async fn delete_file(&self, path: &str) -> anyhow::Result<()>;
 }

--- a/service/src/backend/s3_compatible.rs
+++ b/service/src/backend/s3_compatible.rs
@@ -86,4 +86,16 @@ impl<T: TokenProvider> Backend for S3Compatible<T> {
         let stream = response.bytes_stream().map_err(anyhow::Error::from);
         Ok(Some(stream.boxed()))
     }
+
+    async fn delete_file(&self, path: &str) -> anyhow::Result<()> {
+        let delete_url = format!("{}/{}/{path}", self.endpoint, self.bucket);
+
+        let mut builder = self.client.delete(delete_url);
+        if let Some(provider) = &self.token_provider {
+            builder = builder.bearer_auth(provider.get_token().await?.as_str());
+        }
+        let _response = builder.send().await?;
+
+        Ok(())
+    }
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -68,6 +68,10 @@ impl StorageService {
         self.0.backend.get_file(key).await
     }
 
+    pub async fn delete_file(&self, key: &str) -> anyhow::Result<()> {
+        self.0.backend.delete_file(key).await
+    }
+
     pub async fn _put_file(&self, key: &str, contents: &[u8]) -> anyhow::Result<()> {
         let file_part = self.put_part(contents).await?;
         self.assemble_file_from_parts(key, &[file_part]).await?;

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -5,15 +5,18 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
+argh = "0.1.13"
 bytes = "1.10.1"
-bytesize = "2.0.1"
+bytesize = { version = "2.0.1", features = ["serde"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
+humantime-serde = "1.1.1"
 rand = { version = "0.9.1", features = ["small_rng"] }
 rand_distr = "0.5.1"
 reqwest = { version = "0.12.20", features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+serde_yaml = "0.9.34"
 sketches-ddsketch = "0.3.0"
 tokio = { version = "1.45.1", features = [
     "rt",

--- a/stresstest/example.yaml
+++ b/stresstest/example.yaml
@@ -1,0 +1,15 @@
+remote: http://localhost:8888
+prefix: some/bucket
+
+duration: 2s
+
+workloads:
+  - name: example
+    concurrency: 32
+    file_sizes:
+      p50: 16 KiB
+      p99: 1 MiB
+    actions:
+      writes: 98
+      reads: 2
+      deletes: 0

--- a/stresstest/src/config.rs
+++ b/stresstest/src/config.rs
@@ -1,0 +1,36 @@
+use std::time::Duration;
+
+use bytesize::ByteSize;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub remote: String,
+    pub prefix: String,
+
+    #[serde(with = "humantime_serde")]
+    pub duration: Duration,
+
+    pub workloads: Vec<Workload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Workload {
+    pub name: String,
+    pub concurrency: usize,
+    pub file_sizes: FileSizes,
+    pub actions: Actions,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileSizes {
+    pub p50: ByteSize,
+    pub p99: ByteSize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Actions {
+    pub writes: u8,
+    pub reads: u8,
+    pub deletes: u8,
+}

--- a/stresstest/src/http.rs
+++ b/stresstest/src/http.rs
@@ -8,7 +8,8 @@ use serde::Deserialize;
 use crate::workload::Payload;
 
 pub struct HttpRemote {
-    pub master_url: String,
+    pub remote: String,
+    pub prefix: String,
     pub client: reqwest::Client,
 }
 
@@ -30,7 +31,7 @@ impl HttpRemote {
             Poll::Ready(Some(Ok::<_, Infallible>(read_buf)))
         });
 
-        let put_url = format!("{}/foo/bar", self.master_url);
+        let put_url = format!("{}/{}", self.remote, self.prefix);
         let response = self
             .client
             .put(put_url)
@@ -44,7 +45,7 @@ impl HttpRemote {
     }
 
     pub async fn read(&self, id: &str, mut payload: Payload) {
-        let get_url = format!("{}/{id}", self.master_url);
+        let get_url = format!("{}/{id}", self.remote);
         let file_contents = self
             .client
             .get(get_url)
@@ -64,7 +65,7 @@ impl HttpRemote {
     }
 
     pub async fn delete(&self, id: String) {
-        let delete_url = format!("{}/{id}", self.master_url);
+        let delete_url = format!("{}/{id}", self.remote);
         self.client.delete(delete_url).send().await.unwrap();
     }
 }

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -7,7 +7,7 @@ use rand_distr::weighted::WeightedIndex;
 use rand_distr::{Distribution, LogNormal, Zipf};
 
 pub struct WorkloadBuilder {
-    name: &'static str,
+    name: String,
     concurrency: usize,
     seed: u64,
 
@@ -70,7 +70,7 @@ impl WorkloadBuilder {
 }
 
 pub struct Workload {
-    pub name: &'static str,
+    pub name: String,
     pub concurrency: usize,
 
     /// The RNG driving all our distributions.
@@ -85,9 +85,9 @@ pub struct Workload {
 }
 
 impl Workload {
-    pub fn builder(name: &'static str) -> WorkloadBuilder {
+    pub fn builder(name: impl Into<String>) -> WorkloadBuilder {
         WorkloadBuilder {
-            name,
+            name: name.into(),
             concurrency: available_parallelism().unwrap().get(),
             seed: rand::random(),
 
@@ -149,6 +149,12 @@ impl Workload {
     /// (Files currently being read will not be concurrently deleted)
     pub fn push_file(&mut self, internal: InternalId, external: ExternalId) {
         self.existing_files.push((internal, external))
+    }
+
+    pub fn external_files(&mut self) -> impl Iterator<Item = ExternalId> + use<> {
+        std::mem::take(&mut self.existing_files)
+            .into_iter()
+            .map(|(_internal, external)| external)
     }
 }
 


### PR DESCRIPTION
The stresstester now cleans up after itself, running a `delete` on all the left-over files.

It is also configurable via a yaml format now.