### PR TITLE
ci(gha): Fix CI triggers and job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
+      - release/**
 
   pull_request:
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,7 +6,8 @@ on:
       - main
       - release/**
 
-  pull_request:
+  # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
+  # pull_request:
 
 jobs:
   build:
@@ -47,8 +48,9 @@ jobs:
   assemble-server-image:
     name: Publish
     runs-on: ubuntu-latest
-
     needs: [build]
+
+    # Intentionally never publish on pull requests
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,13 +1,18 @@
+name: Docker
+
 on:
-  pull_request:
   push:
     branches:
       - main
       - release/**
 
+  pull_request:
+
 jobs:
   build:
+    name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         include:
@@ -15,7 +20,7 @@ jobs:
             platform: amd64
           - os: ubuntu-24.04-arm
             platform: arm64
-    name: build-${{ matrix.platform }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -40,9 +45,12 @@ jobs:
           path: /tmp/server-${{ matrix.platform }}.tar
 
   assemble-server-image:
+    name: Publish
     runs-on: ubuntu-latest
+
     needs: [build]
     if: ${{ github.event_name != 'pull_request' }}
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes the branch trigger for CI on `main`, adds CI for `release` branches once we start publishing, and disables docker image builds in PRs to speed up CI and save resources while they are not needed.