### PR TITLE
build(docker): Separate dockerfile for stresstest build

### DIFF
--- a/Dockerfile.stresstest
+++ b/Dockerfile.stresstest
@@ -1,0 +1,33 @@
+FROM rust:slim-bookworm AS build-chef
+
+WORKDIR /work
+RUN cargo install cargo-chef --locked
+
+FROM build-chef AS build-planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin stresstest
+
+FROM build-chef AS build-binary
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends libssl-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-planner /work/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release -p stresstest
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-binary /work/target/release/stresstest /bin
+
+ENTRYPOINT ["/bin/stresstest"]


### PR DESCRIPTION
Similar to https://github.com/getsentry/foundational-storage/pull/35, but builds
the stresstest in a separate dockerfile.

